### PR TITLE
Increase revision number by 100 for 2.0.x builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           version=2.0.$(( 100 + ${{ github.run_number }} ))
           echo $version
-          env.VERSION = $version
+          ${{ env.VERSION }} = $version
 
       - name: Set up QEMU for amd64 and arm64
         uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480  # v1.2.0 (2021-10-22)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           version=2.0.$(( 100 + ${{ github.run_number }} ))
           echo $version
-          ${{ env.VERSION }} = $version
+          $VERSION=$version
 
       - name: Set up QEMU for amd64 and arm64
         uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480  # v1.2.0 (2021-10-22)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build docker image for oereb wms
     runs-on: ubuntu-20.04
     env:
-      VERSION: 2.0.( 100 + ${{ github.run_number}} )
+      VERSION: '2.0.' + ( 100 + ${{ github.run_number }} )
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Override version number
         run: |
           version=2.0.$(( 100 + ${{ github.run_number }} ))
-          echo $version
-          $VERSION=$version
+          echo "VERSION=$version" >> GITHUB_ENV
 
       - name: Set up QEMU for amd64 and arm64
         uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480  # v1.2.0 (2021-10-22)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Override version number
+      - name: Override version number for 2.0.x builds
         run: |
-          version=2.0.$(( 100 + ${{ github.run_number }} ))
-          echo "VERSION=$version" >> GITHUB_ENV
+          echo "VERSION=2.0.$(( 100 + ${{ github.run_number }} ))" >> GITHUB_ENV
 
       - name: Set up QEMU for amd64 and arm64
         uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480  # v1.2.0 (2021-10-22)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build docker image for oereb wms
     runs-on: ubuntu-20.04
     env:
-      VERSION: 2.0.${{ github.run_number + 100 }}
+      VERSION: 2.0.( 100 + ${{ github.run_number}} )
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build docker image for oereb wms
     runs-on: ubuntu-20.04
     env:
-      VERSION: 2.0.${{ github.run_number }}
+      VERSION: 2.0.${{ github.run_number + 100 }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Override version number for 2.0.x builds
         run: |
-          echo "VERSION=2.0.$(( 100 + ${{ github.run_number }} ))" >> GITHUB_ENV
+          echo "VERSION=2.0.$(( 100 + ${{ github.run_number }} ))" >> $GITHUB_ENV
 
       - name: Set up QEMU for amd64 and arm64
         uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480  # v1.2.0 (2021-10-22)
@@ -88,4 +88,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           pull: true
           push: ${{ (github.ref == 'refs/heads/main') && (github.event_name != 'pull_request') && !env.ACT }}
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Override version number
         run: |
-          $version = "2.0."+(100+$(${{ github.run_number }}))
+          $version = 2.0.$(( 100 + ${{ github.run_number }} ))
           echo $version
           env.VERSION = $version
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Override version number
         run: |
-          $version = 2.0.$(( 100 + ${{ github.run_number }} ))
+          version=2.0.$(( 100 + ${{ github.run_number }} ))
           echo $version
           env.VERSION = $version
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,8 @@ jobs:
   make-docker-images:
     name: Build docker image for oereb wms
     runs-on: ubuntu-20.04
-    env:
-      VERSION: 2.0.${{ github.run_number }}
+#    env:
+#      VERSION: 2.0.${{ github.run_number }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build docker image for oereb wms
     runs-on: ubuntu-20.04
     env:
-      VERSION: '2.0.' + ( 100 + ${{ github.run_number }} )
+      VERSION: '2.0.' + ( 100 + $($Env:GITHUB_RUN_NUMBER) )
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,9 @@ jobs:
 
       - name: Override version number
         run: |
-          env.VERSION = '2.0.' + ( 100 + ${{ github.run_number }} )
+          $version = '2.0.' + ( 100 + ${{ github.run_number }} )
+          echo $version
+          env.VERSION = $version
 
       - name: Set up QEMU for amd64 and arm64
         uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480  # v1.2.0 (2021-10-22)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Override version number
         run: |
-          $version = '2.0.' + ( 100 + ${{ github.run_number }} )
+          $version = '2.0.' + ( 100 + $(${{ github.run_number }}) )
           echo $version
           env.VERSION = $version
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build docker image for oereb wms
     runs-on: ubuntu-20.04
     env:
-      VERSION: '2.0.' + ( 100 + $($Env:GITHUB_RUN_NUMBER) )
+      VERSION: "2.0."+(100+$($Env:GITHUB_RUN_NUMBER))
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,14 @@ jobs:
     name: Build docker image for oereb wms
     runs-on: ubuntu-20.04
     env:
-      VERSION: "2.0."+(100+$($Env:GITHUB_RUN_NUMBER))
+      VERSION: 2.0.${{ github.run_number }}
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Override version number
+        run: |
+          env.VERSION = '2.0.' + ( 100 + ${{ github.run_number }} )
 
       - name: Set up QEMU for amd64 and arm64
         uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480  # v1.2.0 (2021-10-22)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Override version number
         run: |
-          $version = '2.0.' + ( 100 + $(${{ github.run_number }}) )
+          $version = "2.0."+(100+$(${{ github.run_number }}))
           echo $version
           env.VERSION = $version
 


### PR DESCRIPTION
Dies ist nötig, weil wir diesen Branch aus dem Repo sogis-oereb/oereb-wms hierher verschoben haben. `${{ github.run_number }}` begann dadurch wieder neu bei 1, wodurch nun neue Images tiefere Revision Numbers als bereits bestehende Images erhalten würden.